### PR TITLE
Fix `create_pipeline() got an unexpected keyword argument 'sagemaker_project_arn' on CodeBuild build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The repository is based on a template described in [SageMaker MLOps Project Walk
 2. https://github.com/aws-samples/amazon-sagemaker-pipelines-mxnet-image-classification/
 
 The pipeline:
-  * Splits the dataset and converts it to RecordIO format in  ([pipelines/road-sign/pipeline.py#L112](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road-sign/pipeline.py#L112)). It is assumed, that the dataset is uploaded to S3 beforehand.
-  * Trains a classification model with transfer learning based on an already trained model ([pipelines/road-sign/pipeline.py#L151](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road-sign/pipeline.py#L151)).
-  * Evaluates the model on the test dataset ([pipelines/road-sign/pipeline.py#L199](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road-sign/pipeline.py#L199)).
-  * Registers the model to a model registry ([pipelines/road-sign/pipeline.py#L251](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road-sign/pipeline.py#L251)) when mean square error from the evaluation is lower than a specified threshold ([pipelines/road-sign/pipeline.py#L273](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road-sign/pipeline.py#L273)).
+  * Splits the dataset and converts it to RecordIO format in  ([pipelines/road_sign/pipeline.py#L112](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road_sign/pipeline.py#L112)). It is assumed, that the dataset is uploaded to S3 beforehand.
+  * Trains a classification model with transfer learning based on an already trained model ([pipelines/road_sign/pipeline.py#L151](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road_sign/pipeline.py#L151)).
+  * Evaluates the model on the test dataset ([pipelines/road_sign/pipeline.py#L199](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road_sign/pipeline.py#L199)).
+  * Registers the model to a model registry ([pipelines/road_sign/pipeline.py#L251](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road_sign/pipeline.py#L251)) when mean square error from the evaluation is lower than a specified threshold ([pipelines/road_sign/pipeline.py#L273](https://github.com/mleonowicz/dlp-model/blob/main/pipelines/road_sign/pipeline.py#L273)).
 
 Model deployment code will be provided in another [dlp-deploy repository](https://github.com/mleonowicz/dlp-deploy).
 
@@ -27,7 +27,7 @@ Team members:
 |-- codebuild-buildspec.yml
 |-- CONTRIBUTING.md
 |-- pipelines
-|   |-- road-sign
+|   |-- road_sign
 |   |   |-- evaluate.py
 |   |   |-- __init__.py
 |   |   |-- pipeline.py

--- a/codebuild-buildspec.yml
+++ b/codebuild-buildspec.yml
@@ -12,7 +12,7 @@ phases:
       - export PYTHONUNBUFFERED=TRUE
       - export SAGEMAKER_PROJECT_NAME_ID="${SAGEMAKER_PROJECT_NAME}-${SAGEMAKER_PROJECT_ID}"
       - |
-        run-pipeline --module-name pipelines.road-sign.pipeline \
+        run-pipeline --module-name pipelines.road_sign.pipeline \
           --role-arn $SAGEMAKER_PIPELINE_ROLE_ARN \
           --tags "[{\"Key\":\"sagemaker:project-name\", \"Value\":\"${SAGEMAKER_PROJECT_NAME}\"}, {\"Key\":\"sagemaker:project-id\", \"Value\":\"${SAGEMAKER_PROJECT_ID}\"}]" \
           --kwargs "{\"region\":\"${AWS_REGION}\",\"sagemaker_project_arn\":\"${SAGEMAKER_PROJECT_ARN}\",\"role\":\"${SAGEMAKER_PIPELINE_ROLE_ARN}\",\"default_bucket\":\"${ARTIFACT_BUCKET}\",\"pipeline_name\":\"${SAGEMAKER_PROJECT_NAME_ID}\",\"model_package_group_name\":\"${SAGEMAKER_PROJECT_NAME_ID}\",\"base_job_prefix\":\"${SAGEMAKER_PROJECT_NAME_ID}\"}"

--- a/pipelines/road_sign/pipeline.py
+++ b/pipelines/road_sign/pipeline.py
@@ -294,6 +294,7 @@ def create_pipeline(
     base_job_prefix="RoadSign",
     processing_instance_type="ml.m5.xlarge",
     training_instance_type="ml.p2.xlarge",  # supress lovely "Instance type X is not supported by algorithm image-classification; only GPU instances are supported." limitation
+    sagemaker_project_arn=None,  # don't remove without refactoring codebuild-buildspec.yml and _utils.py where it's fixed
 ):
     """Gets a SageMaker ML Pipeline instance working with road sign data.
 

--- a/pipelines/road_sign/preprocess.py
+++ b/pipelines/road_sign/preprocess.py
@@ -1,4 +1,4 @@
-"""Feature engineers the road-sign dataset."""
+"""Feature engineers the road sign dataset."""
 import argparse
 import logging
 import shutil


### PR DESCRIPTION
Re-add `sagemaker_project_arn` parameter removed from `create_pipeline` in `_utils.py` in PR #2 .

This parameter is passed to `run_pipeline.py` by CodeBuild build defined in `codebuild-buildspec.yml` to `create_pipeline_custom_tags` *and* `create_pipeline`. This would result in an error like:
```
Exception: create_pipeline() got an unexpected keyword argument 'sagemaker_project_arn'
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pipelines/run_pipeline.py", line 81, in main
    pipeline = create_pipeline_driver(args.module_name, args.kwargs)
  File "/root/.pyenv/versions/3.8.13/lib/python3.8/site-packages/pipelines/_utils.py", line 34, in create_pipeline_driver
    return _imports.create_pipeline(**kwargs)
TypeError: create_pipeline() got an unexpected keyword argument 'sagemaker_project_arn'
```

The PR is needed to unblock CodeBuild build. Offending parameter can be left in-tact or removed from both the functions later on.


