### PR TITLE
Hotfix: Remove explicit null parameter for checkpoint_frequency because of a bug in SageMaker SDK

### DIFF
--- a/pipelines/road_sign/pipeline.py
+++ b/pipelines/road_sign/pipeline.py
@@ -188,7 +188,6 @@ def create_training_step(
         "num_training_samples": TRAIN_NIMAGES,
         "epochs": max_nepoch,
         "learning_rate": learning_rate,
-        "checkpoint_frequency": None,  # save at the best validation accuracy epoch
     }
     classifier = Estimator(
         hyperparameters=hyperparameters,


### PR DESCRIPTION
I wanted to pass an explicit null with a comment to emphasize that there will by a checkpoint saved for an epoch with the best validation set error (`checkpoint_frequency` key in `hyperparameters` dict passed to `sagemaker.estimator.Estimator` that does the training step; reference: [https://docs.aws.amazon.com/sagemaker/latest/dg/IC-Hyperparameter.html](https://docs.aws.amazon.com/sagemaker/latest/dg/IC-Hyperparameter.html)). The change to this key was introduced in the previous PR #5 and  meant to provide an explicit value for the key and was equivalent to the default behaviour (when there is no value provided).
It seems to be impossible because of [https://github.com/aws/sagemaker-python-sdk/issues/613](https://github.com/aws/sagemaker-python-sdk/issues/613): the offending None value would be serialized to 'None' string and the consecutive serialization would cause an error like this:

```
Reading default configuration from /opt/amazon/lib/python3.7/site-packages/image_classification/default-input.json: {'use_pretrained_model': 0, 'num_layers': 152, 'epochs': 30, 'learning_rate': 0.1, 'lr_scheduler_factor': 0.1, 'optimizer': 'sgd', 'momentum': 0, 'weight_decay': 0.0001, 'beta_1': 0.9, 'beta_2': 0.999, 'eps': 1e-08, 'gamma': 0.9, 'mini_batch_size': 32, 'image_shape': '3,224,224', 'precision_dtype': 'float32'}
 Merging with provided configuration from /opt/ml/input/config/hyperparameters.json: {'checkpoint_frequency': 'None', 'epochs': '5', 'learning_rate': '1.0E-5', 'num_classes': '43', 'num_layers': '18', 'num_training_samples': '39209', 'use_pretrained_model': '1'}
Customer Error: The value 'None' is not valid for the 'checkpoint_frequency' hyperparameter which expects one of the following: a string which matches the pattern '^\+?[1-9][0-9]*$'; or an integer greater than 1 (caused by ValidationError)
Caused by: 'None' is not valid under any of the given schemas
Failed validating 'oneOf' in schema['properties']['checkpoint_frequency']:
    {'oneOf': [{'pattern': '^\\+?[1-9][0-9]*$', 'type': 'string'},
               {'minimum': 1, 'type': 'integer'}]}
On instance['checkpoint_frequency']:
    'None'
```


Thus removing this parameter to unblock training step of the SageMaker Pipeline in this PR.